### PR TITLE
Account for inheritance in XIT0004

### DIFF
--- a/src/Xunit.v3.IntegrationTesting.Analyzers.Tests/Analyzers/AttributeUsageDependenciesAnalyzerTests.cs
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers.Tests/Analyzers/AttributeUsageDependenciesAnalyzerTests.cs
@@ -107,6 +107,58 @@ public class AttributeUsageDependenciesAnalyzerTests
         await analyzer.RunAsync(TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task Validate_DependsOn_InheritedMethod_NoDiagnosticAsync()
+    {
+        var source = /* lang=c#-test */ @"
+            using Xunit.v3.IntegrationTesting;
+
+            public class BaseTests
+            {
+                [FactDependsOn]
+                public void BaseTest() { }
+            }
+
+            public class DerivedTests : BaseTests
+            {
+                [FactDependsOn(Dependencies = [nameof(BaseTest)])]
+                public void Test1() { }
+            }
+        ";
+
+        var analyzer = GetAnalyzer(source);
+
+        await analyzer.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Validate_DependsOn_DeepInheritedMethod_NoDiagnosticAsync()
+    {
+        var source = /* lang=c#-test */ @"
+            using Xunit.v3.IntegrationTesting;
+
+            public class GrandparentTests
+            {
+                [FactDependsOn]
+                public void GrandparentTest() { }
+            }
+
+            public class ParentTests : GrandparentTests
+            {
+            }
+
+            public class ChildTests : ParentTests
+            {
+                [FactDependsOn(Dependencies = [nameof(GrandparentTest)])]
+                public void Test1() { }
+            }
+        ";
+
+        var analyzer = GetAnalyzer(source);
+
+        await analyzer.RunAsync(TestContext.Current.CancellationToken);
+    }
+
     private static AnalyzerTest<DefaultVerifier> GetAnalyzer(string source) => new CSharpAnalyzerTest<AttributeUsageDependenciesAnalyzer, DefaultVerifier>
     {
         TestCode = source,

--- a/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageDependenciesAnalyzer.cs
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageDependenciesAnalyzer.cs
@@ -114,15 +114,24 @@ public class AttributeUsageDependenciesAnalyzer : DiagnosticAnalyzer
         if (classSymbol == null)
             return;
 
-        var methodsByName = classSymbol.GetMembers().OfType<IMethodSymbol>().ToDictionary(m => m.Name);
-
         foreach (var depName in dependencies)
         {
-            if (!methodsByName.TryGetValue(depName, out var depMethod))
+            if (!HasMember(classSymbol, depName))
             {
-                // No method with such name
+                // No method with such name in the class or any of its base types
                 context.ReportDiagnostic(Diagnostic.Create(AttributeUsageDescriptors.DependsOnMissingMethod, methodDecl.Identifier.GetLocation(), methodSymbol.Name, depName));
             }
         }
+    }
+
+    private static bool HasMember(INamedTypeSymbol? type, string memberName)
+    {
+        while (type != null)
+        {
+            if (type.GetMembers(memberName).OfType<IMethodSymbol>().Any())
+                return true;
+            type = type.BaseType;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Fixes #15 

This pull request improves the handling of test dependencies in the `AttributeUsageDependenciesAnalyzer` by ensuring that dependencies specified via `FactDependsOn` are correctly recognized even when the dependent methods are inherited from base classes. It also adds new tests to verify this behavior.

**Analyzer logic improvements:**

* Updated the analyzer's dependency check to search for dependent methods not only in the current class, but also in all base classes, by introducing a new `HasMember` helper method that walks the inheritance hierarchy (`AttributeUsageDependenciesAnalyzer.cs`).

**Test coverage enhancements:**

* Added new test cases to verify that no diagnostics are reported when a test method depends on a method inherited from a base class or a grandparent class (`AttributeUsageDependenciesAnalyzerTests.cs`).