### PR TITLE
Ignore xUnit1013

### DIFF
--- a/src/Xunit.v3.IntegrationTesting/FactDependsOnAttribute.cs
+++ b/src/Xunit.v3.IntegrationTesting/FactDependsOnAttribute.cs
@@ -11,9 +11,13 @@ namespace Xunit.v3.IntegrationTesting;
 /// </summary>
 [XunitTestCaseDiscoverer(typeof(FactDiscoverer))]
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[IgnoreXunitAnalyzersRule1013]
 public class FactDependsOnAttribute(
         [CallerFilePath] string? sourceFilePath = null,
         [CallerLineNumber] int sourceLineNumber = -1
     ) : DependsOnAttributeBase(sourceFilePath, sourceLineNumber)
 {
 }
+
+// see https://github.com/xunit/xunit/issues/3387#issuecomment-3750889641
+internal sealed class IgnoreXunitAnalyzersRule1013Attribute : Attribute { }


### PR DESCRIPTION
This pull request introduces an attribute to suppress a specific xUnit analyzer warning on the `FactDependsOnAttribute` class. The main change is the addition of a custom attribute to ignore rule 1013, along with its implementation.

**Analyzer suppression:**

* Added the `IgnoreXunitAnalyzersRule1013Attribute` and applied it to the `FactDependsOnAttribute` class to suppress xUnit analyzer rule 1013, referencing a related issue for context.