### PR TITLE
Add tie breaker for topological sort

### DIFF
--- a/src/Xunit.v3.IntegrationTesting.Analyzers.Tests/Analyzers/AttributeUsageTestCaseOrdererAnalyzerTests.cs
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers.Tests/Analyzers/AttributeUsageTestCaseOrdererAnalyzerTests.cs
@@ -153,6 +153,59 @@ public class AttributeUsageTestCaseOrdererAnalyzerTests
     }
 
     [Fact]
+    public async Task Validate_DependsOn_ClassSubtypeTestCaseOrderer_NoDiagnosticAsync()
+    {
+        var source = /* lang=c#-test */ @"
+            using Xunit;
+            using Xunit.Sdk;
+            using Xunit.v3.IntegrationTesting;
+
+            public class MyCustomOrderer : DependencyAwareTestCaseOrderer
+            {
+                protected override int CompareTestCases(ITestCase x, ITestCase y) => 0;
+            }
+
+            [TestCaseOrderer(typeof(MyCustomOrderer))]
+            public class MyTests
+            {
+                [FactDependsOn]
+                public void Test1() { }
+            }
+        ";
+
+        var analyzer = GetAnalyzer(source);
+
+        await analyzer.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Validate_DependsOn_AssemblySubtypeTestCaseOrderer_NoDiagnosticAsync()
+    {
+        var source = /* lang=c#-test */ @"
+            using Xunit;
+            using Xunit.Sdk;
+            using Xunit.v3.IntegrationTesting;
+
+            [assembly: TestCaseOrderer(typeof(MyCustomOrderer))]
+
+            public class MyCustomOrderer : DependencyAwareTestCaseOrderer
+            {
+                protected override int CompareTestCases(ITestCase x, ITestCase y) => 0;
+            }
+
+            public class MyTests
+            {
+                [FactDependsOn]
+                public void Test1() { }
+            }
+        ";
+
+        var analyzer = GetAnalyzer(source);
+
+        await analyzer.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task Validate_NoDependsOn_NoDiagnosticAsync()
     {
         var source = /* lang=c#-test */ @"

--- a/src/Xunit.v3.IntegrationTesting.Analyzers.Tests/Analyzers/AttributeUsageTestCollectionOrdererAnalyzerTests.cs
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers.Tests/Analyzers/AttributeUsageTestCollectionOrdererAnalyzerTests.cs
@@ -70,6 +70,30 @@ public class AttributeUsageTestCollectionOrdererAnalyzerTests
         await analyzer.RunAsync(TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task Validate_DependsOn_SubtypeCollectionOrderer_NoDiagnosticAsync()
+    {
+        var source = /* lang=c#-test */ @"
+            using Xunit;
+            using Xunit.Sdk;
+            using Xunit.v3.IntegrationTesting;
+
+            [assembly: TestCollectionOrderer(typeof(MyCustomCollectionOrderer))]
+
+            public class MyCustomCollectionOrderer : DependencyAwareTestCollectionOrderer
+            {
+                protected override int CompareTestCollections(ITestCollection x, ITestCollection y) => 0;
+            }
+
+            [DependsOnCollections]
+            public sealed class MyCollection;
+        ";
+
+        var analyzer = GetAnalyzer(source);
+
+        await analyzer.RunAsync(TestContext.Current.CancellationToken);
+    }
+
     private static AnalyzerTest<DefaultVerifier> GetAnalyzer(string source) => new CSharpAnalyzerTest<AttributeUsageTestCollectionOrdererAnalyzer, DefaultVerifier>
     {
         TestCode = source,

--- a/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageTestCaseOrdererAnalyzer.cs
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageTestCaseOrdererAnalyzer.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit.v3.IntegrationTesting.Analyzers.Helpers;
 
 namespace Xunit.v3.IntegrationTesting.Analyzers;
 
@@ -83,7 +84,7 @@ public class AttributeUsageTestCaseOrdererAnalyzer : DiagnosticAnalyzer
                             attr.ArgumentList.Arguments[0].Expression is TypeOfExpressionSyntax typeOfExpr)
                         {
                             var typeSymbol = semanticModel.GetTypeInfo(typeOfExpr.Type).Type;
-                            if (SymbolEqualityComparer.Default.Equals(typeSymbol, dependencyAwareOrdererSymbol))
+                            if (TypeHierarchyHelper.IsOrDerivesFrom(typeSymbol, dependencyAwareOrdererSymbol))
                             {
                                 break;
                             }
@@ -118,7 +119,7 @@ public class AttributeUsageTestCaseOrdererAnalyzer : DiagnosticAnalyzer
                 if (attr.ConstructorArguments.Length == 1)
                 {
                     var arg = attr.ConstructorArguments[0];
-                    if (arg.Kind == TypedConstantKind.Type && SymbolEqualityComparer.Default.Equals(arg.Value as INamedTypeSymbol, dependencyAwareOrdererSymbol))
+                    if (arg.Kind == TypedConstantKind.Type && TypeHierarchyHelper.IsOrDerivesFrom(arg.Value as INamedTypeSymbol, dependencyAwareOrdererSymbol))
                     {
                         break;
                     }
@@ -145,7 +146,7 @@ public class AttributeUsageTestCaseOrdererAnalyzer : DiagnosticAnalyzer
                 if (attr.ConstructorArguments.Length == 1)
                 {
                     var arg = attr.ConstructorArguments[0];
-                    if (arg.Kind == TypedConstantKind.Type && SymbolEqualityComparer.Default.Equals(arg.Value as INamedTypeSymbol, dependencyAwareCollectionOrdererSymbol))
+                    if (arg.Kind == TypedConstantKind.Type && TypeHierarchyHelper.IsOrDerivesFrom(arg.Value as INamedTypeSymbol, dependencyAwareCollectionOrdererSymbol))
                     {
                         break;
                     }

--- a/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageTestCollectionOrdererAnalyzer.cs
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageTestCollectionOrdererAnalyzer.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit.v3.IntegrationTesting.Analyzers.Helpers;
 
 namespace Xunit.v3.IntegrationTesting.Analyzers;
 
@@ -55,7 +56,7 @@ public class AttributeUsageTestCollectionOrdererAnalyzer : DiagnosticAnalyzer
                 if (attr.ConstructorArguments.Length == 1)
                 {
                     var arg = attr.ConstructorArguments[0];
-                    if (arg.Kind == TypedConstantKind.Type && SymbolEqualityComparer.Default.Equals(arg.Value as INamedTypeSymbol, dependencyAwareCollectionOrdererSymbol))
+                    if (arg.Kind == TypedConstantKind.Type && TypeHierarchyHelper.IsOrDerivesFrom(arg.Value as INamedTypeSymbol, dependencyAwareCollectionOrdererSymbol))
                     {
                         break;
                     }

--- a/src/Xunit.v3.IntegrationTesting.Analyzers/Helpers/TypeHierarchyHelper.cs
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers/Helpers/TypeHierarchyHelper.cs
@@ -1,0 +1,25 @@
+using Microsoft.CodeAnalysis;
+
+namespace Xunit.v3.IntegrationTesting.Analyzers.Helpers;
+
+internal static class TypeHierarchyHelper
+{
+    /// <summary>
+    /// Returns true if <paramref name="type"/> is the same as or derives from <paramref name="baseType"/>.
+    /// </summary>
+    public static bool IsOrDerivesFrom(ITypeSymbol? type, ITypeSymbol? baseType)
+    {
+        if (type is null || baseType is null)
+            return false;
+
+        var current = type;
+        while (current != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, baseType))
+                return true;
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+}

--- a/src/Xunit.v3.IntegrationTesting.Tests/OrientedGraphTests.cs
+++ b/src/Xunit.v3.IntegrationTesting.Tests/OrientedGraphTests.cs
@@ -136,6 +136,142 @@ public class OrientedGraphTests
         Assert.Equal(new[] { "A", "B", "C", "A" }, ex.DependencyCycle);
     }
 
+    [Fact]
+    public void Validate_TopologicalSort_WithTieBreaker_RespectsOrder()
+    {
+        // Graph: A depends on nothing, B depends on nothing, C depends on nothing
+        // Tiebreaker: alphabetical order
+        var graph = new OrientedGraph<string>(StringComparer.OrdinalIgnoreCase);
+        graph.AddNode("C");
+        graph.AddNode("A");
+        graph.AddNode("B");
+
+        var sorted = graph.TopologicalSort((x, y) => string.Compare(x, y, StringComparison.Ordinal)).ToList();
+
+        Assert.Equal(new[] { "A", "B", "C" }, sorted);
+    }
+
+    [Fact]
+    public void Validate_TopologicalSort_WithTieBreaker_DependenciesOverridePriority()
+    {
+        // A (priority 3) depends on B (priority 2) which depends on C (priority 1)
+        // Even though C has highest priority, dependency chain is respected: C, B, A
+        var graph = new OrientedGraph<string>(StringComparer.OrdinalIgnoreCase);
+        graph.AddEdge("A", "B");
+        graph.AddEdge("B", "C");
+
+        var priorities = new Dictionary<string, int> { ["A"] = 3, ["B"] = 2, ["C"] = 1 };
+        var sorted = graph.TopologicalSort((x, y) => priorities[x].CompareTo(priorities[y])).ToList();
+
+        Assert.Equal(new[] { "C", "B", "A" }, sorted);
+    }
+
+    [Fact]
+    public void Validate_TopologicalSort_WithTieBreaker_SameLevelSortedByPriority()
+    {
+        // D depends on nothing (priority 1)
+        // C depends on nothing (priority 2)
+        // B depends on nothing (priority 3)
+        // A depends on B, C, D (priority 4)
+        var graph = new OrientedGraph<string>(StringComparer.OrdinalIgnoreCase);
+        graph.AddEdge("A", "B");
+        graph.AddEdge("A", "C");
+        graph.AddEdge("A", "D");
+
+        var priorities = new Dictionary<string, int> { ["A"] = 4, ["B"] = 3, ["C"] = 2, ["D"] = 1 };
+        var sorted = graph.TopologicalSort((x, y) => priorities[x].CompareTo(priorities[y])).ToList();
+
+        // D, C, B are all at level 0 (no deps), sorted by priority: D(1), C(2), B(3)
+        // A is at level 1 (after all deps resolved)
+        Assert.Equal(new[] { "D", "C", "B", "A" }, sorted);
+    }
+
+    [Fact]
+    public void Validate_TopologicalSort_WithTieBreaker_MultiLevel()
+    {
+        // Level 0: E(1), F(2) - no deps
+        // Level 1: C(1) depends on E, D(2) depends on F
+        // Level 2: A(1) depends on C and D, B(2) depends on D
+        var graph = new OrientedGraph<string>(StringComparer.OrdinalIgnoreCase);
+        graph.AddEdge("A", "C");
+        graph.AddEdge("A", "D");
+        graph.AddEdge("B", "D");
+        graph.AddEdge("C", "E");
+        graph.AddEdge("D", "F");
+
+        var priorities = new Dictionary<string, int>
+        {
+            ["E"] = 1, ["F"] = 2,
+            ["C"] = 1, ["D"] = 2,
+            ["A"] = 1, ["B"] = 2
+        };
+        var sorted = graph.TopologicalSort((x, y) => priorities[x].CompareTo(priorities[y])).ToList();
+
+        // Level 0: E(1) before F(2)
+        AssertInOrder(sorted, "E", "F");
+        // Level 1: C(1) before D(2)
+        AssertInOrder(sorted, "C", "D");
+        // Dependencies respected
+        AssertInOrder(sorted, "E", "C");
+        AssertInOrder(sorted, "F", "D");
+        AssertInOrder(sorted, "C", "A");
+        AssertInOrder(sorted, "D", "A");
+        AssertInOrder(sorted, "D", "B");
+        // Level 2: A(1) before B(2)
+        AssertInOrder(sorted, "A", "B");
+    }
+
+    [Fact]
+    public void Validate_TopologicalSort_WithTieBreaker_CircularDependency_Throws()
+    {
+        var graph = new OrientedGraph<string>(StringComparer.OrdinalIgnoreCase);
+        graph.AddEdge("A", "B");
+        graph.AddEdge("B", "C");
+        graph.AddEdge("C", "A");
+
+        Assert.Throws<CircularDependencyException<string>>(
+            () => graph.TopologicalSort((x, y) => string.Compare(x, y, StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void Validate_TopologicalSort_WithTieBreaker_AllNodesPresent()
+    {
+        var graph = new OrientedGraph<string>(StringComparer.OrdinalIgnoreCase);
+        graph.AddEdge("D", "E");
+        graph.AddEdge("Y", "D");
+        graph.AddEdge("X", "D");
+        graph.AddEdge("Z", "Y");
+        graph.AddEdge("Z", "X");
+
+        var sorted = graph.TopologicalSort((x, y) => 0).ToList();
+
+        Assert.Equal(5, sorted.Count);
+        Assert.Contains("E", sorted);
+        Assert.Contains("D", sorted);
+        Assert.Contains("Y", sorted);
+        Assert.Contains("X", sorted);
+        Assert.Contains("Z", sorted);
+    }
+
+    [Fact]
+    public void Validate_TopologicalSort_WithTieBreaker_RespectsDependencies()
+    {
+        var graph = new OrientedGraph<string>(StringComparer.OrdinalIgnoreCase);
+        graph.AddEdge("D", "E");
+        graph.AddEdge("Y", "D");
+        graph.AddEdge("X", "D");
+        graph.AddEdge("Z", "Y");
+        graph.AddEdge("Z", "X");
+
+        var sorted = graph.TopologicalSort((x, y) => 0).ToList();
+
+        AssertInOrder(sorted, "E", "D");
+        AssertInOrder(sorted, "D", "Y");
+        AssertInOrder(sorted, "D", "X");
+        AssertInOrder(sorted, "Y", "Z");
+        AssertInOrder(sorted, "X", "Z");
+    }
+
     private void AssertInOrder(List<string> sorted, string first, string second)
     {
         var firstIndex = sorted.IndexOf(first);

--- a/src/Xunit.v3.IntegrationTesting/DependencyAwareTestCaseOrderer.cs
+++ b/src/Xunit.v3.IntegrationTesting/DependencyAwareTestCaseOrderer.cs
@@ -1,22 +1,76 @@
+using System.Globalization;
 using Xunit.Sdk;
+using Xunit.v3.IntegrationTesting.Exceptions;
+using Xunit.v3.IntegrationTesting.Extensions;
 
 namespace Xunit.v3.IntegrationTesting;
 
 /// <summary>
-/// Delegates to <see cref="DependsOnAttributeBase.Orderer"/>.
-/// Kept for backward compatibility and assembly-level attribute registration.
+/// Orders test cases based on dependencies declared via <see cref="DependsOnAttributeBase"/>.
+/// Subclass and override <see cref="CompareTestCases"/> to provide secondary ordering
+/// (e.g., by priority) for test cases at the same dependency level.
 /// </summary>
 public class DependencyAwareTestCaseOrderer : ITestCaseOrderer
 {
-    private readonly DependsOnAttributeBase.Orderer _inner = new();
+    /// <summary>
+    /// Compares two test cases for ordering within the same dependency level.
+    /// Override to provide secondary ordering (e.g., by priority) among tests
+    /// that have no dependency relationship.
+    /// <para>
+    /// Return a negative value if <paramref name="x"/> should run before <paramref name="y"/>,
+    /// zero if no preference, or a positive value if <paramref name="y"/> should run first.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// This comparison only affects ordering of tests that are at the same "level" in the
+    /// dependency graph. It cannot override dependency constraints: if test A depends on
+    /// test B, B will always run before A regardless of this comparison.
+    /// </remarks>
+    protected virtual int CompareTestCases(ITestCase x, ITestCase y) => 0;
 
     /// <inheritdoc />
     public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
         where TTestCase : notnull, ITestCase
-        => _inner.OrderTestCases(testCases);
+        => OrderTestCasesCore(testCases);
 
     /// <inheritdoc />
     public IReadOnlyCollection<TTestCase> OrderTestCases<TTestCase>(IReadOnlyCollection<TTestCase> testCases)
         where TTestCase : notnull, ITestCase
-        => _inner.OrderTestCases(testCases);
+        => OrderTestCasesCore(testCases).ToList();
+
+    private IEnumerable<TTestCase> OrderTestCasesCore<TTestCase>(IEnumerable<TTestCase> testCases)
+        where TTestCase : notnull, ITestCase
+    {
+        try
+        {
+            var graph = testCases.ToOrientedGraph(out var issues);
+            var orderedCases = graph.TopologicalSort((x, y) => CompareTestCases(x, y));
+
+            foreach (var issue in issues)
+            {
+                TestContext.Current.SendDiagnosticMessage("[TEST CASE ORDERER WARNING] " + issue);
+            }
+
+            return orderedCases.Cast<TTestCase>();
+        }
+        catch (CircularDependencyException<IXunitTestCase> ex)
+        {
+            var circularDependencyMessage = string.Format(
+                CultureInfo.CurrentCulture,
+                "There's a circular dependency involving the following tests: {0}",
+                string.Join(" -> ", ex.DependencyCycle.Select(tc => $"{tc.TestClassName}.{tc.TestMethodName}")));
+
+            TestContext.Current.SendDiagnosticMessage("[TEST CASE ORDERER ERROR] " +
+                circularDependencyMessage);
+
+            return testCases.ToArray();
+        }
+        catch (Exception ex)
+        {
+            var message = "An unexpected error occurred while ordering test cases: " + ex.Message;
+            TestContext.Current.SendDiagnosticMessage("[TEST CASE ORDERER ERROR] " + message);
+
+            return testCases.ToArray();
+        }
+    }
 }

--- a/src/Xunit.v3.IntegrationTesting/DependencyAwareTestCollectionOrderer.cs
+++ b/src/Xunit.v3.IntegrationTesting/DependencyAwareTestCollectionOrderer.cs
@@ -1,22 +1,75 @@
+using System.Globalization;
 using Xunit.Sdk;
+using Xunit.v3.IntegrationTesting.Exceptions;
+using Xunit.v3.IntegrationTesting.Extensions;
 
 namespace Xunit.v3.IntegrationTesting;
 
 /// <summary>
-/// Delegates to <see cref="DependsOnCollectionsAttribute.Orderer"/>.
-/// Kept for backward compatibility and assembly-level attribute registration.
+/// Orders test collections based on dependencies declared via <see cref="DependsOnCollectionsAttribute"/>.
+/// Subclass and override <see cref="CompareTestCollections"/> to provide secondary ordering
+/// (e.g., by priority) for collections at the same dependency level.
 /// </summary>
 public class DependencyAwareTestCollectionOrderer : ITestCollectionOrderer
 {
-    private readonly DependsOnCollectionsAttribute.Orderer _inner = new();
+    /// <summary>
+    /// Compares two test collections for ordering within the same dependency level.
+    /// Override to provide secondary ordering (e.g., by priority) among collections
+    /// that have no dependency relationship.
+    /// <para>
+    /// Return a negative value if <paramref name="x"/> should run before <paramref name="y"/>,
+    /// zero if no preference, or a positive value if <paramref name="y"/> should run first.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// This comparison only affects ordering of collections that are at the same "level" in the
+    /// dependency graph. It cannot override dependency constraints.
+    /// </remarks>
+    protected virtual int CompareTestCollections(ITestCollection x, ITestCollection y) => 0;
 
     /// <inheritdoc />
     public IEnumerable<TTestCollection> OrderTestCollections<TTestCollection>(IEnumerable<TTestCollection> testCollections)
         where TTestCollection : ITestCollection
-        => _inner.OrderTestCollections(testCollections);
+        => OrderTestCollectionsCore(testCollections);
 
     /// <inheritdoc />
     public IReadOnlyCollection<TTestCollection> OrderTestCollections<TTestCollection>(IReadOnlyCollection<TTestCollection> testCollections)
         where TTestCollection : ITestCollection
-        => _inner.OrderTestCollections(testCollections);
+        => OrderTestCollectionsCore(testCollections).Cast<TTestCollection>().ToList();
+
+    private IEnumerable<TTestCollection> OrderTestCollectionsCore<TTestCollection>(IEnumerable<TTestCollection> testCollections)
+        where TTestCollection : ITestCollection
+    {
+        try
+        {
+            var graph = testCollections.CollectionsToOrientedGraph(out var issues);
+            var orderedCollections = graph.TopologicalSort((x, y) => CompareTestCollections(x, y));
+
+            foreach (var issue in issues)
+            {
+                TestContext.Current.SendDiagnosticMessage("[TEST COLLECTION ORDERER WARNING] " + issue);
+            }
+
+            return orderedCollections;
+        }
+        catch (CircularDependencyException<IXunitTestCollection> ex)
+        {
+            var circularDependencyMessage = string.Format(
+                CultureInfo.CurrentCulture,
+                "There's a circular dependency involving the following test collections: {0}",
+                string.Join(" -> ", ex.DependencyCycle.Select(tc => tc.TestCollectionDisplayName)));
+
+            TestContext.Current.SendDiagnosticMessage("[TEST COLLECTION ORDERER ERROR] " +
+                circularDependencyMessage);
+
+            throw new TestPipelineException(
+                circularDependencyMessage, ex);
+        }
+        catch (Exception ex)
+        {
+            var message = "An unexpected error occurred while ordering test collections: " + ex.Message;
+            TestContext.Current.SendDiagnosticMessage("[TEST COLLECTION ORDERER ERROR] " + message);
+            throw new TestPipelineException(message, ex);
+        }
+    }
 }

--- a/src/Xunit.v3.IntegrationTesting/DependsOnAttributeBase.cs
+++ b/src/Xunit.v3.IntegrationTesting/DependsOnAttributeBase.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.Reflection;
 using Xunit.Sdk;
 using Xunit.v3;
-using Xunit.v3.IntegrationTesting.Exceptions;
 using Xunit.v3.IntegrationTesting.Extensions;
 
 namespace Xunit.v3.IntegrationTesting;
@@ -20,51 +19,10 @@ public abstract class DependsOnAttributeBase(
 {
     /// <summary>
     /// Test case orderer that orders tests based on dependencies declared via <see cref="DependsOnAttributeBase"/>.
+    /// Delegates to <see cref="DependencyAwareTestCaseOrderer"/> for backward compatibility.
     /// </summary>
-    internal class Orderer : ITestCaseOrderer
+    internal class Orderer : DependencyAwareTestCaseOrderer
     {
-        /// <inheritdoc />
-        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
-            where TTestCase : notnull, ITestCase
-        {
-            try
-            {
-                var graph = testCases.ToOrientedGraph(out var issues);
-                var orderedCases = graph.TopologicalSort();
-
-                foreach (var issue in issues)
-                {
-                    TestContext.Current.SendDiagnosticMessage("[TEST CASE ORDERER WARNING] " + issue);
-                }
-
-                return orderedCases.Cast<TTestCase>();
-            }
-            catch (CircularDependencyException<IXunitTestCase> ex)
-            {
-                var circularDependencyMessage = string.Format(
-                    CultureInfo.CurrentCulture,
-                    "There's a circular dependency involving the following tests: {0}",
-                    string.Join(" -> ", ex.DependencyCycle.Select(tc => $"{tc.TestClassName}.{tc.TestMethodName}")));
-
-                TestContext.Current.SendDiagnosticMessage("[TEST CASE ORDERER ERROR] " +
-                    circularDependencyMessage);
-
-                return testCases.ToArray();
-            }
-            catch (Exception ex)
-            {
-                var message = "An unexpected error occurred while ordering test cases: " + ex.Message;
-                TestContext.Current.SendDiagnosticMessage("[TEST CASE ORDERER ERROR] " + message);
-
-                return testCases.ToArray();
-            }
-        }
-
-        /// <inheritdoc />
-        public IReadOnlyCollection<TTestCase> OrderTestCases<TTestCase>(IReadOnlyCollection<TTestCase> testCases) where TTestCase : notnull, ITestCase
-        {
-            return OrderTestCases(testCases.AsEnumerable()).ToList();
-        }
     }
 
     /// <inheritdoc/>

--- a/src/Xunit.v3.IntegrationTesting/DependsOnCollectionsAttribute.cs
+++ b/src/Xunit.v3.IntegrationTesting/DependsOnCollectionsAttribute.cs
@@ -1,8 +1,3 @@
-using System.Globalization;
-using Xunit.Sdk;
-using Xunit.v3.IntegrationTesting.Extensions;
-using Xunit.v3.IntegrationTesting.Exceptions;
-
 namespace Xunit.v3.IntegrationTesting;
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
@@ -12,51 +7,9 @@ public class DependsOnCollectionsAttribute(params Type[] dependencies) : Attribu
 
     /// <summary>
     /// Test collection orderer that orders collections based on dependencies declared via <see cref="DependsOnCollectionsAttribute"/>.
+    /// Delegates to <see cref="DependencyAwareTestCollectionOrderer"/> for backward compatibility.
     /// </summary>
-    internal class Orderer : ITestCollectionOrderer
+    internal class Orderer : DependencyAwareTestCollectionOrderer
     {
-        /// <inheritdoc />
-        public IEnumerable<TTestCollection> OrderTestCollections<TTestCollection>(IEnumerable<TTestCollection> testCollections)
-            where TTestCollection : ITestCollection
-        {
-            try
-            {
-                var graph = testCollections.CollectionsToOrientedGraph(out var issues);
-                var orderedCollections = graph.TopologicalSort();
-
-                foreach (var issue in issues)
-                {
-                    TestContext.Current.SendDiagnosticMessage("[TEST COLLECTION ORDERER WARNING] " + issue);
-                }
-
-                return orderedCollections;
-            }
-            catch (CircularDependencyException<IXunitTestCollection> ex)
-            {
-                var circularDependencyMessage = string.Format(
-                    CultureInfo.CurrentCulture,
-                    "There's a circular dependency involving the following test collections: {0}",
-                    string.Join(" -> ", ex.DependencyCycle.Select(tc => tc.TestCollectionDisplayName)));
-
-                TestContext.Current.SendDiagnosticMessage("[TEST COLLECTION ORDERER ERROR] " +
-                    circularDependencyMessage);
-
-                throw new TestPipelineException(
-                    circularDependencyMessage, ex);
-            }
-            catch (Exception ex)
-            {
-                var message = "An unexpected error occurred while ordering test collections: " + ex.Message;
-                TestContext.Current.SendDiagnosticMessage("[TEST COLLECTION ORDERER ERROR] " + message);
-                throw new TestPipelineException(message, ex);
-            }
-        }
-
-        /// <inheritdoc />
-        public IReadOnlyCollection<TTestCollection> OrderTestCollections<TTestCollection>(IReadOnlyCollection<TTestCollection> testCollections)
-            where TTestCollection : ITestCollection
-        {
-            return OrderTestCollections(testCollections.AsEnumerable()).Cast<TTestCollection>().ToList();
-        }
     }
 }

--- a/src/Xunit.v3.IntegrationTesting/OrientedGraph.cs
+++ b/src/Xunit.v3.IntegrationTesting/OrientedGraph.cs
@@ -72,6 +72,70 @@ internal class OrientedGraph<TNode>
         return sorted;
     }
 
+    /// <summary>
+    /// Performs a topological sort using Kahn's algorithm with a tiebreaker comparison
+    /// for nodes at the same dependency level. This allows secondary ordering
+    /// (e.g., by priority) among nodes that have no dependency relationship.
+    /// </summary>
+    public IEnumerable<TNode> TopologicalSort(Comparison<TNode> tieBreaker)
+    {
+        // Build reverse adjacency (who depends on me?) and compute in-degrees
+        var inDegree = new Dictionary<TNode, int>(_comparer);
+        var dependents = new Dictionary<TNode, List<TNode>>(_comparer);
+
+        foreach (var node in GetAllNodes())
+        {
+            if (!inDegree.ContainsKey(node))
+                inDegree[node] = 0;
+            if (!dependents.ContainsKey(node))
+                dependents[node] = new List<TNode>();
+        }
+
+        foreach (var node in GetAllNodes())
+        {
+            foreach (var dep in GetNeighbors(node))
+            {
+                inDegree[node]++;
+                dependents[dep].Add(node);
+            }
+        }
+
+        // Ready queue: nodes with no dependencies, sorted by tiebreaker
+        var ready = new List<TNode>();
+        foreach (var kvp in inDegree)
+        {
+            if (kvp.Value == 0)
+                ready.Add(kvp.Key);
+        }
+        ready.Sort(tieBreaker);
+
+        var sorted = new List<TNode>();
+        while (ready.Count > 0)
+        {
+            var current = ready[0];
+            ready.RemoveAt(0);
+            sorted.Add(current);
+
+            foreach (var dependent in dependents[current])
+            {
+                inDegree[dependent]--;
+                if (inDegree[dependent] == 0)
+                {
+                    ready.Add(dependent);
+                    ready.Sort(tieBreaker);
+                }
+            }
+        }
+
+        if (sorted.Count != inDegree.Count)
+        {
+            // Cycle detected - delegate to DFS-based sort for proper cycle reporting
+            TopologicalSort();
+        }
+
+        return sorted;
+    }
+
     public IEnumerable<TNode> GetSubTree(TNode node)
     {
         var visited = new HashSet<TNode>(_comparer);


### PR DESCRIPTION
This pull request introduces significant improvements to test dependency ordering in the xUnit integration testing framework. The main focus is on making the dependency-aware test case and collection orderers extensible by allowing custom secondary ordering (tie-breakers) among tests or collections at the same dependency level. It also enhances diagnostics and error handling, and ensures analyzers correctly recognize subclasses of dependency-aware orderers. Comprehensive tests and helper utilities are added to verify and support these behaviors.

**Dependency-aware orderer extensibility and diagnostics:**

* Refactored `DependencyAwareTestCaseOrderer` and `DependencyAwareTestCollectionOrderer` to allow subclasses to override `CompareTestCases`/`CompareTestCollections` for custom secondary ordering among items at the same dependency level. Improved error handling and diagnostic messages for circular dependencies and unexpected errors. [[1]](diffhunk://#diff-e7964ead675595dab168bde07ef54b9156e3e23d4bdcc9a84deb51f7abf4ec4aR1-R75) [[2]](diffhunk://#diff-4e5d309fa3fbd5ac9ecf9691b40b0a41597f1a69e984818b7164dd02dd6c1d84R1-R74)
* Removed legacy/delegating orderer logic from `DependsOnAttributeBase` and `DependsOnCollectionsAttribute` to centralize dependency ordering logic in the new extensible orderers.

**Analyzer improvements:**

* Updated analyzers to use a new `TypeHierarchyHelper.IsOrDerivesFrom` utility, so that specifying a subclass of a dependency-aware orderer is now recognized as valid. This change applies to both test case and test collection orderer analyzers. [[1]](diffhunk://#diff-a89f749d935a0d3b6cd88f02c97643290860cb196d8428c55381ac75569f8ed2R6) [[2]](diffhunk://#diff-a89f749d935a0d3b6cd88f02c97643290860cb196d8428c55381ac75569f8ed2L86-R87) [[3]](diffhunk://#diff-a89f749d935a0d3b6cd88f02c97643290860cb196d8428c55381ac75569f8ed2L121-R122) [[4]](diffhunk://#diff-a89f749d935a0d3b6cd88f02c97643290860cb196d8428c55381ac75569f8ed2L148-R149) [[5]](diffhunk://#diff-5347f068436afd7b721bcf61df41e0a0d9293f8f1771a8432b1f9e8c2d17d38eR6) [[6]](diffhunk://#diff-5347f068436afd7b721bcf61df41e0a0d9293f8f1771a8432b1f9e8c2d17d38eL58-R59) [[7]](diffhunk://#diff-824f91673373cf1eccf46b525d0acf24ff255cdeb3fe6cec112201f2b85c482dR1-R25)
* Added new analyzer tests to verify that specifying a subclass of a dependency-aware orderer does not produce diagnostics. [[1]](diffhunk://#diff-2c2ab8c2a5c221618410b9c905671dcb14cc60588280d5831ce2ffc82adb458dR155-R207) [[2]](diffhunk://#diff-13314a132c981ca6aaad786ab35419bd0945ea01e64688e0a9d5a3d00034af28R73-R96)

**Test coverage for topological sort with tie-breakers:**

* Added comprehensive tests to `OrientedGraphTests` to verify that the topological sort respects dependencies, supports custom tie-breakers, and correctly handles edge cases (such as cycles and multi-level graphs).