### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Following rules are included as part of the package:
 | XIT0010 | Warning | `CollectionDefinition` with `DependsOnCollections` must have `DisableParallelization` set to `true` |
 | XIT0011 | Warning | `DependsOnCollections` attribute requires assembly-level `TestCollectionOrderer` |
 | XIT0012 | Warning | `DependsOnCollections` attribute requires assembly-level `TestCollectionOrderer` to be `DependencyAwareTestCollectionOrderer` to respect test dependencies |
+| XIT0013 | Warning | `DependsOnClasses` dependency type already belongs to a collection; use `[DependsOnCollections]` directly instead |
+| XIT0014 | Warning | `DependsOnClasses` dependency type is not part of a named collection; add `[DependsOnClasses(Name = "...")]` to it so a collection definition is generated |
+| XIT0015 | Warning | Method has multiple attributes derived from `DependsOnAttributeBase`; only one is allowed per method |
+| XIT0016 | Warning | Method has a `DependsOnAttributeBase`-derived attribute combined with another `IFactAttribute`; use only the DependsOn attribute |
 
 # Common questions
 


### PR DESCRIPTION
This pull request updates the documentation to include new rule warnings related to dependency attributes in test collections. The main change is the addition of four new warning codes to the rules table in the `README.md`.

**Documentation updates:**

* Added warning XIT0013: Warns when a `DependsOnClasses` dependency type already belongs to a collection, suggesting to use `[DependsOnCollections]` directly instead.
* Added warning XIT0014: Warns when a `DependsOnClasses` dependency type is not part of a named collection, recommending to add `[DependsOnClasses(Name = "...")]` for proper collection definition generation.
* Added warning XIT0015: Warns when a method has multiple attributes derived from `DependsOnAttributeBase`, indicating only one is allowed per method.
* Added warning XIT0016: Warns when a method combines a `DependsOnAttributeBase`-derived attribute with another `IFactAttribute`, advising to use only the DependsOn attribute.