### PR TITLE
Update documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Xunit.v3.IntegrationTesting Rules
+
+|Id|Category|Description|Severity|Is enabled|Code fix|
+|--|--------|-----------|:------:|:--------:|:------:|
+|[XIT0001](Rules/XIT0001.md)|Usage|Class-level `TestCaseOrderer` should be `DependencyAwareTestCaseOrderer`|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0002](Rules/XIT0002.md)|Usage|Assembly-level `TestCaseOrderer` should be `DependencyAwareTestCaseOrderer`|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0003](Rules/XIT0003.md)|Usage|Project is missing class-level and assembly-level `TestCaseOrderer` attribute|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0004](Rules/XIT0004.md)|Usage|`FactDependsOn` has a dependency on a test method that doesn't exist|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0006](Rules/XIT0006.md)|Usage|Assembly is missing `TestFramework` attribute|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0007](Rules/XIT0007.md)|Usage|Assembly `TestFramework` attribute does not extend `DependencyAwareFramework`|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0008](Rules/XIT0008.md)|Usage|`[Fact]`/`[Theory]` should be `[FactDependsOn]`/`[TheoryDependsOn]` in collections with dependencies|<span title='Warning'>⚠️</span>|✔️|✔️|
+|[XIT0009](Rules/XIT0009.md)|Usage|`DependsOnCollections` applied to a class that is not a collection definition|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0010](Rules/XIT0010.md)|Usage|`CollectionDefinition` with `DependsOnCollections` must have `DisableParallelization = true`|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0011](Rules/XIT0011.md)|Usage|`DependsOnCollections` requires assembly-level `TestCollectionOrderer`|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0012](Rules/XIT0012.md)|Usage|Assembly-level `TestCollectionOrderer` should be `DependencyAwareTestCollectionOrderer`|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0013](Rules/XIT0013.md)|Usage|`DependsOnClasses` dependency type already belongs to a collection|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0014](Rules/XIT0014.md)|Usage|`DependsOnClasses` dependency type is not part of a named collection|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0015](Rules/XIT0015.md)|Usage|Method has multiple `DependsOn` attributes|<span title='Warning'>⚠️</span>|✔️|❌|
+|[XIT0016](Rules/XIT0016.md)|Usage|`DependsOn` attribute combined with another `IFactAttribute`|<span title='Warning'>⚠️</span>|✔️|❌|

--- a/docs/Rules/XIT0001.md
+++ b/docs/Rules/XIT0001.md
@@ -1,5 +1,7 @@
 # XIT0001 - Class-level TestCaseOrderer should be DependencyAwareTestCaseOrderer
 
+Source: [AttributeUsageTestCaseOrdererAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageTestCaseOrdererAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0001|

--- a/docs/Rules/XIT0001.md
+++ b/docs/Rules/XIT0001.md
@@ -1,0 +1,27 @@
+# XIT0001 - Class-level TestCaseOrderer should be DependencyAwareTestCaseOrderer
+
+|Property|Value|
+|--|--|
+|Id|XIT0001|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+A method uses `[FactDependsOn]` (or `[TheoryDependsOn]`), but the class-level `[TestCaseOrderer]` is not `DependencyAwareTestCaseOrderer`. Without the correct orderer, tests will not be ordered according to their declared dependencies.
+
+## How to fix
+
+Set the class-level `[TestCaseOrderer]` to `DependencyAwareTestCaseOrderer`:
+
+```csharp
+[TestCaseOrderer(typeof(DependencyAwareTestCaseOrderer))]
+public class MyTests
+{
+    [FactDependsOn(Dependencies = [nameof(Test2)])]
+    public void Test1() { }
+
+    [FactDependsOn]
+    public void Test2() { }
+}
+```

--- a/docs/Rules/XIT0002.md
+++ b/docs/Rules/XIT0002.md
@@ -1,0 +1,19 @@
+# XIT0002 - Assembly-level TestCaseOrderer should be DependencyAwareTestCaseOrderer
+
+|Property|Value|
+|--|--|
+|Id|XIT0002|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+A method uses `[FactDependsOn]` (or `[TheoryDependsOn]`), but the assembly-level `[TestCaseOrderer]` is not `DependencyAwareTestCaseOrderer`. Without the correct orderer, tests will not be ordered according to their declared dependencies.
+
+## How to fix
+
+Set the assembly-level `[TestCaseOrderer]` to `DependencyAwareTestCaseOrderer`:
+
+```csharp
+[assembly: TestCaseOrderer(typeof(DependencyAwareTestCaseOrderer))]
+```

--- a/docs/Rules/XIT0002.md
+++ b/docs/Rules/XIT0002.md
@@ -1,5 +1,7 @@
 # XIT0002 - Assembly-level TestCaseOrderer should be DependencyAwareTestCaseOrderer
 
+Source: [AttributeUsageTestCaseOrdererAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageTestCaseOrdererAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0002|

--- a/docs/Rules/XIT0003.md
+++ b/docs/Rules/XIT0003.md
@@ -1,5 +1,7 @@
 # XIT0003 - Missing TestCaseOrderer attribute
 
+Source: [AttributeUsageTestCaseOrdererAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageTestCaseOrdererAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0003|

--- a/docs/Rules/XIT0003.md
+++ b/docs/Rules/XIT0003.md
@@ -1,0 +1,19 @@
+# XIT0003 - Missing TestCaseOrderer attribute
+
+|Property|Value|
+|--|--|
+|Id|XIT0003|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+A method uses `[FactDependsOn]` (or `[TheoryDependsOn]`), but neither `DependencyAwareTestCaseOrderer` nor `DependencyAwareTestCollectionOrderer` is set as a class-level or assembly-level orderer. Without an orderer, test execution order is not guaranteed to respect declared dependencies.
+
+## How to fix
+
+Add an assembly-level or class-level `[TestCaseOrderer]`:
+
+```csharp
+[assembly: TestCaseOrderer(typeof(DependencyAwareTestCaseOrderer))]
+```

--- a/docs/Rules/XIT0004.md
+++ b/docs/Rules/XIT0004.md
@@ -1,5 +1,7 @@
 # XIT0004 - Missing test dependency
 
+Source: [AttributeUsageDependenciesAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageDependenciesAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0004|

--- a/docs/Rules/XIT0004.md
+++ b/docs/Rules/XIT0004.md
@@ -1,0 +1,23 @@
+# XIT0004 - Missing test dependency
+
+|Property|Value|
+|--|--|
+|Id|XIT0004|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+A `[FactDependsOn]` or `[TheoryDependsOn]` attribute references a method name in its `Dependencies` property that does not exist in the containing class. This likely indicates a typo or a renamed/removed test method.
+
+## How to fix
+
+Ensure all names listed in `Dependencies` correspond to existing methods in the same class:
+
+```csharp
+[FactDependsOn(Dependencies = [nameof(Test2)])]
+public void Test1() { }
+
+[FactDependsOn]
+public void Test2() { }
+```

--- a/docs/Rules/XIT0006.md
+++ b/docs/Rules/XIT0006.md
@@ -1,5 +1,7 @@
 # XIT0006 - Missing TestFramework assembly attribute
 
+Source: [AttributeUsageTestFrameworkAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageTestFrameworkAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0006|

--- a/docs/Rules/XIT0006.md
+++ b/docs/Rules/XIT0006.md
@@ -1,0 +1,19 @@
+# XIT0006 - Missing TestFramework assembly attribute
+
+|Property|Value|
+|--|--|
+|Id|XIT0006|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+The assembly uses `[FactDependsOn]` or `[TheoryDependsOn]` but is missing `[assembly: TestFramework(typeof(DependencyAwareFramework))]`. Without this attribute, filtered or partial test runs (e.g. selecting specific tests in Test Explorer or filtering via CLI) may not discover transitive dependencies, causing them to be skipped.
+
+## How to fix
+
+Add the assembly-level attribute (or set `UseDependencyAwareTestFramework` to `true` in your project file — this is the default):
+
+```csharp
+[assembly: TestFramework(typeof(DependencyAwareFramework))]
+```

--- a/docs/Rules/XIT0007.md
+++ b/docs/Rules/XIT0007.md
@@ -1,0 +1,23 @@
+# XIT0007 - TestFramework attribute does not extend DependencyAwareFramework
+
+|Property|Value|
+|--|--|
+|Id|XIT0007|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+The assembly has an `[assembly: TestFramework(...)]` attribute, but the specified type does not extend `DependencyAwareFramework`. This means filtered or partial test runs may not discover transitive dependencies.
+
+## How to fix
+
+Change your custom framework to extend `DependencyAwareFramework` (or `DependencySkippingFramework`) instead of `XunitTestFramework`:
+
+```csharp
+public class MyCustomFramework : DependencyAwareFramework
+{
+    protected override DependencyAwareFrameworkExecutor CreateExecutor(IXunitTestAssembly testAssembly)
+        => new MyCustomExecutor(testAssembly);
+}
+```

--- a/docs/Rules/XIT0007.md
+++ b/docs/Rules/XIT0007.md
@@ -1,5 +1,7 @@
 # XIT0007 - TestFramework attribute does not extend DependencyAwareFramework
 
+Source: [AttributeUsageTestFrameworkAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageTestFrameworkAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0007|

--- a/docs/Rules/XIT0008.md
+++ b/docs/Rules/XIT0008.md
@@ -1,5 +1,7 @@
 # XIT0008 - Use FactDependsOn/TheoryDependsOn in collections with dependencies
 
+Sources: [AttributeUsageDependsOnAttributeAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageDependsOnAttributeAnalyzer.cs), [DependsOnAttributeFixer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Fixers/DependsOnAttributeFixer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0008|

--- a/docs/Rules/XIT0008.md
+++ b/docs/Rules/XIT0008.md
@@ -1,0 +1,29 @@
+# XIT0008 - Use FactDependsOn/TheoryDependsOn in collections with dependencies
+
+|Property|Value|
+|--|--|
+|Id|XIT0008|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|✔️|
+
+A test method uses `[Fact]` or `[Theory]` in a class belonging to a collection with `[DependsOnCollections]` dependencies. Without `[FactDependsOn]` or `[TheoryDependsOn]`, the skip logic for upstream collection failures will not run and the test will execute even when its collection dependencies have failed.
+
+This rule is suppressed when `DependencySkippingFramework` is in use, because that framework handles collection-level skipping at the runner level for all test attributes.
+
+## How to fix
+
+Replace `[Fact]` with `[FactDependsOn]` and `[Theory]` with `[TheoryDependsOn]`:
+
+```csharp
+// Before
+[Fact]
+public void Test1() { }
+
+// After
+[FactDependsOn]
+public void Test1() { }
+```
+
+A code fix is available that performs this replacement automatically.

--- a/docs/Rules/XIT0009.md
+++ b/docs/Rules/XIT0009.md
@@ -1,5 +1,7 @@
 # XIT0009 - DependsOnCollections applied to non-collection definition
 
+Source: [AttributeUsageCollectionDependenciesAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageCollectionDependenciesAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0009|

--- a/docs/Rules/XIT0009.md
+++ b/docs/Rules/XIT0009.md
@@ -1,0 +1,21 @@
+# XIT0009 - DependsOnCollections applied to non-collection definition
+
+|Property|Value|
+|--|--|
+|Id|XIT0009|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+The `[DependsOnCollections]` attribute is applied to a class that is not a collection definition (i.e. it does not have `[CollectionDefinition]`). This attribute only has meaning on collection definitions.
+
+## How to fix
+
+Move the `[DependsOnCollections]` attribute to the corresponding collection definition class:
+
+```csharp
+[CollectionDefinition("MyCollection", DisableParallelization = true)]
+[DependsOnCollections(Dependencies = ["OtherCollection"])]
+public class MyCollectionDefinition { }
+```

--- a/docs/Rules/XIT0010.md
+++ b/docs/Rules/XIT0010.md
@@ -1,0 +1,21 @@
+# XIT0010 - CollectionDefinition with DependsOnCollections must disable parallelization
+
+|Property|Value|
+|--|--|
+|Id|XIT0010|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+A `[CollectionDefinition]` with `[DependsOnCollections]` does not have `DisableParallelization = true`. When parallelization is enabled, collections run concurrently and the declared dependency order is not guaranteed.
+
+## How to fix
+
+Set `DisableParallelization = true` on the `[CollectionDefinition]`:
+
+```csharp
+[CollectionDefinition("MyCollection", DisableParallelization = true)]
+[DependsOnCollections(Dependencies = ["OtherCollection"])]
+public class MyCollectionDefinition { }
+```

--- a/docs/Rules/XIT0010.md
+++ b/docs/Rules/XIT0010.md
@@ -1,5 +1,7 @@
 # XIT0010 - CollectionDefinition with DependsOnCollections must disable parallelization
 
+Source: [AttributeUsageCollectionDependenciesAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageCollectionDependenciesAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0010|

--- a/docs/Rules/XIT0011.md
+++ b/docs/Rules/XIT0011.md
@@ -1,5 +1,7 @@
 # XIT0011 - DependsOnCollections requires assembly-level TestCollectionOrderer
 
+Source: [AttributeUsageTestCollectionOrdererAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageTestCollectionOrdererAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0011|

--- a/docs/Rules/XIT0011.md
+++ b/docs/Rules/XIT0011.md
@@ -1,0 +1,19 @@
+# XIT0011 - DependsOnCollections requires assembly-level TestCollectionOrderer
+
+|Property|Value|
+|--|--|
+|Id|XIT0011|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+A `[DependsOnCollections]` attribute is present but no assembly-level `[TestCollectionOrderer]` is declared. Without the orderer, collection execution order is not guaranteed to respect declared dependencies.
+
+## How to fix
+
+Add an assembly-level `[TestCollectionOrderer]` (or set `UseDependencyAwareTestCollectionOrderer` to `true` in your project file — this is the default):
+
+```csharp
+[assembly: TestCollectionOrderer(typeof(DependencyAwareTestCollectionOrderer))]
+```

--- a/docs/Rules/XIT0012.md
+++ b/docs/Rules/XIT0012.md
@@ -1,0 +1,19 @@
+# XIT0012 - Assembly-level TestCollectionOrderer should be DependencyAwareTestCollectionOrderer
+
+|Property|Value|
+|--|--|
+|Id|XIT0012|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+A `[DependsOnCollections]` attribute is present but the assembly-level `[TestCollectionOrderer]` is not `DependencyAwareTestCollectionOrderer`. Without the correct orderer, collection execution order will not respect declared dependencies.
+
+## How to fix
+
+Set the assembly-level `[TestCollectionOrderer]` to `DependencyAwareTestCollectionOrderer`:
+
+```csharp
+[assembly: TestCollectionOrderer(typeof(DependencyAwareTestCollectionOrderer))]
+```

--- a/docs/Rules/XIT0012.md
+++ b/docs/Rules/XIT0012.md
@@ -1,5 +1,7 @@
 # XIT0012 - Assembly-level TestCollectionOrderer should be DependencyAwareTestCollectionOrderer
 
+Source: [AttributeUsageTestCollectionOrdererAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageTestCollectionOrdererAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0012|

--- a/docs/Rules/XIT0013.md
+++ b/docs/Rules/XIT0013.md
@@ -1,0 +1,21 @@
+# XIT0013 - DependsOnClasses dependency already belongs to a collection
+
+|Property|Value|
+|--|--|
+|Id|XIT0013|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+A type referenced in `[DependsOnClasses]` already belongs to a collection (has `[Collection]` or `[CollectionDefinition]`). The source generator cannot create a new collection for it. Use `[DependsOnCollections]` on the collection definition directly instead.
+
+## How to fix
+
+Use `[DependsOnCollections]` to declare the dependency at the collection level:
+
+```csharp
+[CollectionDefinition("MyCollection", DisableParallelization = true)]
+[DependsOnCollections(Dependencies = ["OtherCollection"])]
+public class MyCollectionDefinition { }
+```

--- a/docs/Rules/XIT0013.md
+++ b/docs/Rules/XIT0013.md
@@ -1,5 +1,7 @@
 # XIT0013 - DependsOnClasses dependency already belongs to a collection
 
+Source: [AttributeUsageDependsOnClassesAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageDependsOnClassesAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0013|

--- a/docs/Rules/XIT0014.md
+++ b/docs/Rules/XIT0014.md
@@ -1,5 +1,7 @@
 # XIT0014 - DependsOnClasses dependency is not part of a named collection
 
+Source: [AttributeUsageDependsOnClassesAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageDependsOnClassesAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0014|

--- a/docs/Rules/XIT0014.md
+++ b/docs/Rules/XIT0014.md
@@ -1,0 +1,24 @@
+# XIT0014 - DependsOnClasses dependency is not part of a named collection
+
+|Property|Value|
+|--|--|
+|Id|XIT0014|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+A type referenced in `[DependsOnClasses]` is not part of a named collection. For the source generator to create proper collection definitions and ordering, each dependency must also have `[DependsOnClasses(Name = "...")]` so a collection is generated for it.
+
+## How to fix
+
+Add `[DependsOnClasses]` with the `Name` property to the dependency class:
+
+```csharp
+[DependsOnClasses(Name = "DependencyCollection")]
+public class DependencyClass
+{
+    [FactDependsOn]
+    public void Test1() { }
+}
+```

--- a/docs/Rules/XIT0015.md
+++ b/docs/Rules/XIT0015.md
@@ -1,0 +1,26 @@
+# XIT0015 - Multiple DependsOn attributes on one method
+
+|Property|Value|
+|--|--|
+|Id|XIT0015|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+A test method has multiple attributes derived from `DependsOnAttributeBase` (e.g. both `[FactDependsOn]` and `[TheoryDependsOn]`). Only one such attribute is allowed per method.
+
+## How to fix
+
+Remove the extra attribute so that only one `DependsOnAttributeBase`-derived attribute remains:
+
+```csharp
+// Before (invalid)
+[FactDependsOn]
+[TheoryDependsOn]
+public void Test1() { }
+
+// After
+[FactDependsOn]
+public void Test1() { }
+```

--- a/docs/Rules/XIT0015.md
+++ b/docs/Rules/XIT0015.md
@@ -1,5 +1,7 @@
 # XIT0015 - Multiple DependsOn attributes on one method
 
+Source: [MultipleDependsOnAttributeAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/MultipleDependsOnAttributeAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0015|

--- a/docs/Rules/XIT0016.md
+++ b/docs/Rules/XIT0016.md
@@ -1,0 +1,26 @@
+# XIT0016 - DependsOn attribute combined with another IFactAttribute
+
+|Property|Value|
+|--|--|
+|Id|XIT0016|
+|Category|Usage|
+|Severity|<span title='Warning'>⚠️</span>|
+|Enabled|✔️|
+|Code fix|❌|
+
+A test method has an attribute derived from `DependsOnAttributeBase` (e.g. `[FactDependsOn]` or `[TheoryDependsOn]`) combined with another `IFactAttribute` (e.g. `[Fact]` or `[Theory]`). The DependsOn attribute already acts as a fact/theory attribute, so the extra attribute is redundant and may cause unexpected behavior.
+
+## How to fix
+
+Remove the extra `[Fact]` or `[Theory]` attribute:
+
+```csharp
+// Before (invalid)
+[FactDependsOn]
+[Fact]
+public void Test1() { }
+
+// After
+[FactDependsOn]
+public void Test1() { }
+```

--- a/docs/Rules/XIT0016.md
+++ b/docs/Rules/XIT0016.md
@@ -1,5 +1,7 @@
 # XIT0016 - DependsOn attribute combined with another IFactAttribute
 
+Source: [MultipleDependsOnAttributeAnalyzer.cs](../../src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/MultipleDependsOnAttributeAnalyzer.cs)
+
 |Property|Value|
 |--|--|
 |Id|XIT0016|

--- a/docs/Test-collection-dependencies.md
+++ b/docs/Test-collection-dependencies.md
@@ -37,8 +37,50 @@ if we want `CollectionC` to depend on the other two (meaning all tests that belo
 You can also specify `typeof` of a concrete test class, instead of collection definition. Then at runtime it would be translated into getting the actual collection this test class is part of and taking dependency on that.
 
 Now, if you don't have a collection definition, there are two options to declare dependencies
-1. Create a an empty collection definition (like in the above example) and declare dependencies like was described
+1. Create an empty collection definition (like in the above example) and declare dependencies like was described
 2. Decorate a test class with `[DependsOnClasses(...)]` attribute, which will lead to source-generated empty collection definition with all the dependencies declared
+
+## DependsOnClasses attribute
+
+`[DependsOnClasses]` is a simplified syntax for declaring class-level dependencies without manually creating collection definitions. It has two properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Name` | `string` (required) | The collection name. The class is treated as belonging to this collection (the attribute implements `ICollectionAttribute`). |
+| `Dependencies` | `Type[]` | The types this class depends on. Can be other test classes or collection definitions. |
+
+A source generator automatically creates a corresponding `[CollectionDefinition]` class with `DisableParallelization = true` and a `[DependsOnCollections]` attribute pointing to the dependency types.
+
+For example, given:
+
+```csharp
+[DependsOnClasses(Dependencies = [typeof(ClassB), typeof(ClassC)], Name = "DefinitionA")]
+public class ClassA
+{
+    [FactDependsOn]
+    public void Test1() { }
+}
+
+[DependsOnClasses(Name = "DefinitionB")]
+public class ClassB
+{
+    [FactDependsOn]
+    public void Test2() { }
+}
+```
+
+The source generator will emit something like:
+
+```csharp
+[CollectionDefinition("DefinitionA", DisableParallelization = true)]
+[DependsOnCollections(typeof(ClassB), typeof(ClassC))]
+public sealed class Generated_CollectionDefinition_ClassA;
+
+[CollectionDefinition("DefinitionB", DisableParallelization = true)]
+public sealed class Generated_CollectionDefinition_ClassB;
+```
+
+**Important:** Each dependency class must also belong to a named collection. If a dependency class doesn't have `[DependsOnClasses(Name = "...")]` (or an explicit `[Collection]`/`[CollectionDefinition]`), analyzer rule XIT0014 will warn you. Conversely, if a dependency class already belongs to an explicit collection, XIT0013 will suggest using `[DependsOnCollections]` directly instead.
 
 Ordering collections is achieved by having the following assembly level attribute
 ```csharp

--- a/src/Xunit.v3.IntegrationTesting.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,26 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+## Release 1.0.11
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+XIT0001 | Usage | Warning | Not supported class-level test case orderer. Use DependencyAwareTestCaseOrderer
+XIT0002 | Usage | Warning | Not supported assembly-level test case orderer. Use DependencyAwareTestCaseOrderer
+XIT0003 | Usage | Warning | Missing test case orderer or collection case orderer. Use DependencyAwareTestCaseOrderer or DependencyAwareTestCollectionOrderer
+XIT0004 | Usage | Warning | Missing test dependency
+; XIT0005 is reserved and intentionally unused
+XIT0006 | Usage | Warning | Add assembly level [assembly: TestFramework(typeof(DependencyAwareFramework))] attribute to support partial test runs
+XIT0007 | Usage | Warning | Use [assembly: TestFramework(typeof(DependencyAwareFramework))] attribute to support partial test runs
+XIT0008 | Usage | Warning | Use FactDependsOn attribute for tests in collections with dependencies
+XIT0009 | Usage | Warning | Apply DependsOnCollections attribute only to collection definitions
+XIT0010 | Usage | Warning | CollectionDefinition with DependsOnCollections must have DisableParallelization set to true
+XIT0011 | Usage | Warning | DependsOnCollections attribute requires assembly-level TestCollectionOrderer
+XIT0012 | Usage | Warning | DependsOnCollections attribute requires assembly-level TestCollectionOrderer to be DependencyAwareTestCollectionOrderer to respect test dependencies
+XIT0013 | Usage | Warning | DependsOnClasses dependency type already belongs to a collection
+XIT0014 | Usage | Warning | DependsOnClasses dependency type is not part of a named collection
+XIT0015 | Usage | Warning | Method has multiple DependsOn attributes
+XIT0016 | Usage | Warning | Method has DependsOn attribute combined with another IFactAttribute
+

--- a/src/Xunit.v3.IntegrationTesting.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,23 +1,3 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-XIT0001 | Usage | Warning | Not supported class-level test case orderer. Use DependencyAwareTestCaseOrderer
-XIT0002 | Usage | Warning | Not supported assembly-level test case orderer. Use DependencyAwareTestCaseOrderer
-XIT0003 | Usage | Warning | Missing test case orderer or collection case orderer. Use DependencyAwareTestCaseOrderer or DependencyAwareTestCollectionOrderer
-XIT0004 | Usage | Warning | Missing test dependency
-; XIT0005 is reserved and intentionally unused
-XIT0006 | Usage | Warning | Add assembly level [assembly: TestFramework(typeof(DependencyAwareFramework))] attribute to support partial test runs
-XIT0007 | Usage | Warning | Use [assembly: TestFramework(typeof(DependencyAwareFramework))] attribute to support partial test runs
-XIT0008 | Usage | Warning | Use FactDependsOn attribute for tests in collections with dependencies
-XIT0009 | Usage | Warning | Apply DependsOnCollections attribute only to collection definitions
-XIT0010 | Usage | Warning | CollectionDefinition with DependsOnCollections must have DisableParallelization set to true
-XIT0011 | Usage | Warning | DependsOnCollections attribute requires assembly-level TestCollectionOrderer
-XIT0012 | Usage | Warning | DependsOnCollections attribute requires assembly-level TestCollectionOrderer to be DependencyAwareTestCollectionOrderer to respect test dependencies
-XIT0013 | Usage | Warning | DependsOnClasses dependency type already belongs to a collection
-XIT0014 | Usage | Warning | DependsOnClasses dependency type is not part of a named collection
-XIT0015 | Usage | Warning | Method has multiple DependsOn attributes
-XIT0016 | Usage | Warning | Method has DependsOn attribute combined with another IFactAttribute

--- a/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageDescriptors.cs
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageDescriptors.cs
@@ -11,7 +11,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Any method with [FactDependsOn] must have DependencyAwareTestCaseOrderer set TestCaseOrderer, in order for test to be ordered according to defined dependencies.");
+        description: "Any method with [FactDependsOn] must have DependencyAwareTestCaseOrderer set TestCaseOrderer, in order for test to be ordered according to defined dependencies.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.NotSupportedClassLevelTestCaseOrderer));
 
     public static readonly DiagnosticDescriptor NotSupportedAssemblyLevelTestCaseOrderer = new DiagnosticDescriptor(
         DiagnosticIds.NotSupportedAssemblyLevelTestCaseOrderer,
@@ -20,7 +21,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Any method with [FactDependsOn] must have DependencyAwareTestCaseOrderer set TestCaseOrderer, in order for test to be ordered according to defined dependencies.");
+        description: "Any method with [FactDependsOn] must have DependencyAwareTestCaseOrderer set TestCaseOrderer, in order for test to be ordered according to defined dependencies.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.NotSupportedAssemblyLevelTestCaseOrderer));
 
     public static readonly DiagnosticDescriptor MissingTestCaseAndCollectionOrderer = new DiagnosticDescriptor(
         DiagnosticIds.MissingTestCaseAndCollectionOrderer,
@@ -29,7 +31,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Any method with [FactDependsOn] must have DependencyAwareTestCaseOrderer set TestCaseOrderer, in order for test to be ordered according to defined dependencies.");
+        description: "Any method with [FactDependsOn] must have DependencyAwareTestCaseOrderer set TestCaseOrderer, in order for test to be ordered according to defined dependencies.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.MissingTestCaseAndCollectionOrderer));
 
     public static readonly DiagnosticDescriptor DependsOnMissingMethod = new DiagnosticDescriptor(
         DiagnosticIds.DependsOnMissingMethod,
@@ -38,7 +41,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "[FactDependsOn] attribute requires all listed dependencies to be present in the class.");
+        description: "[FactDependsOn] attribute requires all listed dependencies to be present in the class.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.DependsOnMissingMethod));
 
     public static readonly DiagnosticDescriptor MissingTestFrameworkAttribute = new DiagnosticDescriptor(
         DiagnosticIds.MissingTestFrameworkAttribute,
@@ -48,7 +52,8 @@ internal static class AttributeUsageDescriptors
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         customTags: WellKnownDiagnosticTags.CompilationEnd,
-        description: "Assemblies using FactDependsOn attribute on tests should declare [assembly: TestFramework(typeof(DependencyAwareFramework))] to support full test discovery during filtered test execution.");
+        description: "Assemblies using FactDependsOn attribute on tests should declare [assembly: TestFramework(typeof(DependencyAwareFramework))] to support full test discovery during filtered test execution.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.MissingTestFrameworkAttribute));
 
     public static readonly DiagnosticDescriptor NotSupportedTestFrameworkAttribute = new DiagnosticDescriptor(
         DiagnosticIds.NotSupportedTestFrameworkAttribute,
@@ -58,7 +63,8 @@ internal static class AttributeUsageDescriptors
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         customTags: WellKnownDiagnosticTags.CompilationEnd,
-        description: "Assemblies using FactDependsOn attribute on tests should declare [assembly: TestFramework(typeof(DependencyAwareFramework))] (or a type derived from it) to support full test discovery during filtered test execution.");
+        description: "Assemblies using FactDependsOn attribute on tests should declare [assembly: TestFramework(typeof(DependencyAwareFramework))] (or a type derived from it) to support full test discovery during filtered test execution.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.NotSupportedTestFrameworkAttribute));
 
     public static readonly DiagnosticDescriptor UseFactDependsOnAttribute = new DiagnosticDescriptor(
         DiagnosticIds.UseFactDependsOnAttribute,
@@ -67,7 +73,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Test methods in classes belonging to collections with [DependsOnCollections] dependencies should use [FactDependsOn] or [TheoryDependsOn] instead of [Fact] or [Theory]. Without dependency-aware attributes, the skip logic for upstream collection failures will not run and the test will execute even when its collection dependencies have failed.");
+        description: "Test methods in classes belonging to collections with [DependsOnCollections] dependencies should use [FactDependsOn] or [TheoryDependsOn] instead of [Fact] or [Theory]. Without dependency-aware attributes, the skip logic for upstream collection failures will not run and the test will execute even when its collection dependencies have failed.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.UseFactDependsOnAttribute));
 
     public static readonly DiagnosticDescriptor InvalidDependsOnCollectionsAttributeUsage = new DiagnosticDescriptor(
         DiagnosticIds.InvalidDependsOnCollectionsAttributeUsage,
@@ -76,7 +83,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "DependsOnCollections attribute should apply only to collection definitions.");
+        description: "DependsOnCollections attribute should apply only to collection definitions.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.InvalidDependsOnCollectionsAttributeUsage));
 
     public static readonly DiagnosticDescriptor CollectionDefinitionMissingDisableParallelization = new DiagnosticDescriptor(
         DiagnosticIds.CollectionDefinitionMissingDisableParallelization,
@@ -85,7 +93,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Collection definitions with DependsOnCollections attribute must have DisableParallelization set to true to ensure sequential execution order according to declared dependencies.");
+        description: "Collection definitions with DependsOnCollections attribute must have DisableParallelization set to true to ensure sequential execution order according to declared dependencies.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.CollectionDefinitionMissingDisableParallelization));
 
     public static readonly DiagnosticDescriptor MissingTestCollectionOrderer = new DiagnosticDescriptor(
         DiagnosticIds.MissingTestCollectionOrderer,
@@ -94,7 +103,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Usage of [DependsOnCollections] requires DependencyAwareTestCollectionOrderer set as TestCollectionOrderer, in order for test collections to be ordered according to defined dependencies.");
+        description: "Usage of [DependsOnCollections] requires DependencyAwareTestCollectionOrderer set as TestCollectionOrderer, in order for test collections to be ordered according to defined dependencies.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.MissingTestCollectionOrderer));
 
     public static readonly DiagnosticDescriptor NotSupportedTestCollectionOrderer = new DiagnosticDescriptor(
         DiagnosticIds.NotSupportedTestCollectionOrderer,
@@ -103,7 +113,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Usage of [DependsOnCollections] requires DependencyAwareTestCollectionOrderer set as TestCollectionOrderer, in order for test collections to be ordered according to defined dependencies.");
+        description: "Usage of [DependsOnCollections] requires DependencyAwareTestCollectionOrderer set as TestCollectionOrderer, in order for test collections to be ordered according to defined dependencies.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.NotSupportedTestCollectionOrderer));
 
     public static readonly DiagnosticDescriptor DependsOnClassesDependencyAlreadyInCollection = new DiagnosticDescriptor(
         DiagnosticIds.DependsOnClassesDependencyAlreadyInCollection,
@@ -112,7 +123,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "[DependsOnClasses] should only reference classes that are not already part of a collection. If the dependency class has [Collection] or [CollectionDefinition], use [DependsOnCollections] on the collection definition instead.");
+        description: "[DependsOnClasses] should only reference classes that are not already part of a collection. If the dependency class has [Collection] or [CollectionDefinition], use [DependsOnCollections] on the collection definition instead.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.DependsOnClassesDependencyAlreadyInCollection));
 
     public static readonly DiagnosticDescriptor DependsOnClassesDependencyNotInCollection = new DiagnosticDescriptor(
         DiagnosticIds.DependsOnClassesDependencyNotInCollection,
@@ -121,7 +133,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Each dependency in [DependsOnClasses] must belong to a named collection so that collection ordering works reliably. Add [DependsOnClasses(Name = \"...\")] to the dependency class to ensure a collection definition is auto-generated for it.");
+        description: "Each dependency in [DependsOnClasses] must belong to a named collection so that collection ordering works reliably. Add [DependsOnClasses(Name = \"...\")] to the dependency class to ensure a collection definition is auto-generated for it.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.DependsOnClassesDependencyNotInCollection));
 
     public static readonly DiagnosticDescriptor MultipleDependsOnAttributes = new DiagnosticDescriptor(
         DiagnosticIds.MultipleDependsOnAttributes,
@@ -130,7 +143,8 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "A test method should have at most one attribute derived from DependsOnAttributeBase (e.g. [FactDependsOn] or [TheoryDependsOn]). Having multiple dependency attributes on the same method is not supported.");
+        description: "A test method should have at most one attribute derived from DependsOnAttributeBase (e.g. [FactDependsOn] or [TheoryDependsOn]). Having multiple dependency attributes on the same method is not supported.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.MultipleDependsOnAttributes));
 
     public static readonly DiagnosticDescriptor DependsOnWithOtherFactAttributes = new DiagnosticDescriptor(
         DiagnosticIds.DependsOnWithOtherFactAttributes,
@@ -139,5 +153,6 @@ internal static class AttributeUsageDescriptors
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "A test method with an attribute derived from DependsOnAttributeBase (e.g. [FactDependsOn] or [TheoryDependsOn]) should not also have another IFactAttribute (e.g. [Fact] or [Theory]). The DependsOn attribute already acts as a fact/theory attribute.");
+        description: "A test method with an attribute derived from DependsOnAttributeBase (e.g. [FactDependsOn] or [TheoryDependsOn]) should not also have another IFactAttribute (e.g. [Fact] or [Theory]). The DependsOn attribute already acts as a fact/theory attribute.",
+        helpLinkUri: DiagnosticIds.CreateLink(DiagnosticIds.DependsOnWithOtherFactAttributes));
 }

--- a/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageDescriptors.cs
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/AttributeUsageDescriptors.cs
@@ -5,7 +5,7 @@ namespace Xunit.v3.IntegrationTesting.Analyzers;
 internal static class AttributeUsageDescriptors
 {
     public static readonly DiagnosticDescriptor NotSupportedClassLevelTestCaseOrderer = new DiagnosticDescriptor(
-        "XIT0001",
+        DiagnosticIds.NotSupportedClassLevelTestCaseOrderer,
         "FactDependsOn attribute requires DependencyAwareTestCaseOrderer to respect test dependencies",
         "Method '{0}' uses [FactDependsOn] attribute, but class-level test orderer is not DependencyAwareTestCaseOrderer",
         "Usage",
@@ -14,7 +14,7 @@ internal static class AttributeUsageDescriptors
         description: "Any method with [FactDependsOn] must have DependencyAwareTestCaseOrderer set TestCaseOrderer, in order for test to be ordered according to defined dependencies.");
 
     public static readonly DiagnosticDescriptor NotSupportedAssemblyLevelTestCaseOrderer = new DiagnosticDescriptor(
-        "XIT0002",
+        DiagnosticIds.NotSupportedAssemblyLevelTestCaseOrderer,
         "FactDependsOn attribute requires DependencyAwareTestCaseOrderer to respect test dependencies",
         "Method '{0}' uses [FactDependsOn] attribute, but assembly-level test orderer is not DependencyAwareTestCaseOrderer",
         "Usage",
@@ -23,7 +23,7 @@ internal static class AttributeUsageDescriptors
         description: "Any method with [FactDependsOn] must have DependencyAwareTestCaseOrderer set TestCaseOrderer, in order for test to be ordered according to defined dependencies.");
 
     public static readonly DiagnosticDescriptor MissingTestCaseAndCollectionOrderer = new DiagnosticDescriptor(
-        "XIT0003",
+        DiagnosticIds.MissingTestCaseAndCollectionOrderer,
         "FactDependsOn attribute requires DependencyAwareTestCaseOrderer or DependencyAwareTestCollectionOrderer to respect test dependencies",
         "Method '{0}' uses [FactDependsOn] attribute, but neither DependencyAwareTestCaseOrderer nor DependencyAwareTestCollectionOrderer are set as class-level or assembly-level test case orderer",
         "Usage",
@@ -32,7 +32,7 @@ internal static class AttributeUsageDescriptors
         description: "Any method with [FactDependsOn] must have DependencyAwareTestCaseOrderer set TestCaseOrderer, in order for test to be ordered according to defined dependencies.");
 
     public static readonly DiagnosticDescriptor DependsOnMissingMethod = new DiagnosticDescriptor(
-        "XIT0004",
+        DiagnosticIds.DependsOnMissingMethod,
         "Missing test dependency",
         "Method '{0}' depends on method '{1}' but it is missing from the class",
         "Usage",
@@ -41,7 +41,7 @@ internal static class AttributeUsageDescriptors
         description: "[FactDependsOn] attribute requires all listed dependencies to be present in the class.");
 
     public static readonly DiagnosticDescriptor MissingTestFrameworkAttribute = new DiagnosticDescriptor(
-        "XIT0006",
+        DiagnosticIds.MissingTestFrameworkAttribute,
         "Missing TestFramework assembly attribute",
         "Assembly is missing [assembly: TestFramework(typeof(DependencyAwareFramework))]. This can affect filtered test runs (filtering test cases in command line or selecting subset of tests in UI).",
         "Usage",
@@ -51,7 +51,7 @@ internal static class AttributeUsageDescriptors
         description: "Assemblies using FactDependsOn attribute on tests should declare [assembly: TestFramework(typeof(DependencyAwareFramework))] to support full test discovery during filtered test execution.");
 
     public static readonly DiagnosticDescriptor NotSupportedTestFrameworkAttribute = new DiagnosticDescriptor(
-        "XIT0007",
+        DiagnosticIds.NotSupportedTestFrameworkAttribute,
         "Not supported TestFramework assembly attribute",
         "Assembly has existing [assembly: TestFramework(typeof(...))] attribute. Consider extending DependencyAwareFramework instead of XunitTestFramework. Otherwise filtered test runs might be affected.",
         "Usage",
@@ -61,7 +61,7 @@ internal static class AttributeUsageDescriptors
         description: "Assemblies using FactDependsOn attribute on tests should declare [assembly: TestFramework(typeof(DependencyAwareFramework))] (or a type derived from it) to support full test discovery during filtered test execution.");
 
     public static readonly DiagnosticDescriptor UseFactDependsOnAttribute = new DiagnosticDescriptor(
-        "XIT0008",
+        DiagnosticIds.UseFactDependsOnAttribute,
         "Use FactDependsOn/TheoryDependsOn attribute for tests in collections with dependencies",
         "Method '{0}' uses [Fact] or [Theory] in a class belonging to a collection with dependencies; use [FactDependsOn] or [TheoryDependsOn] to enable dependency-aware skipping",
         "Usage",
@@ -70,7 +70,7 @@ internal static class AttributeUsageDescriptors
         description: "Test methods in classes belonging to collections with [DependsOnCollections] dependencies should use [FactDependsOn] or [TheoryDependsOn] instead of [Fact] or [Theory]. Without dependency-aware attributes, the skip logic for upstream collection failures will not run and the test will execute even when its collection dependencies have failed.");
 
     public static readonly DiagnosticDescriptor InvalidDependsOnCollectionsAttributeUsage = new DiagnosticDescriptor(
-        "XIT0009",
+        DiagnosticIds.InvalidDependsOnCollectionsAttributeUsage,
         "Apply DependsOnCollections attribute to collection definitions",
         "Class '{0}' is not a collection definition, it cannot use [DependsOnCollections] attribute",
         "Usage",
@@ -79,7 +79,7 @@ internal static class AttributeUsageDescriptors
         description: "DependsOnCollections attribute should apply only to collection definitions.");
 
     public static readonly DiagnosticDescriptor CollectionDefinitionMissingDisableParallelization = new DiagnosticDescriptor(
-        "XIT0010",
+        DiagnosticIds.CollectionDefinitionMissingDisableParallelization,
         "CollectionDefinition with DependsOnCollections must have DisableParallelization set to true",
         "Collection definition '{0}' has DependsOnCollections attribute, but DisableParallelization is not set to true. This means that collections execution order won't be guaranteed.",
         "Usage",
@@ -88,7 +88,7 @@ internal static class AttributeUsageDescriptors
         description: "Collection definitions with DependsOnCollections attribute must have DisableParallelization set to true to ensure sequential execution order according to declared dependencies.");
 
     public static readonly DiagnosticDescriptor MissingTestCollectionOrderer = new DiagnosticDescriptor(
-        "XIT0011",
+        DiagnosticIds.MissingTestCollectionOrderer,
         "DependsOnCollections attribute requires assembly-level TestCollectionOrderer",
         "[DependsOnCollections] attribute requires assembly-level test collection orderer",
         "Usage",
@@ -97,7 +97,7 @@ internal static class AttributeUsageDescriptors
         description: "Usage of [DependsOnCollections] requires DependencyAwareTestCollectionOrderer set as TestCollectionOrderer, in order for test collections to be ordered according to defined dependencies.");
 
     public static readonly DiagnosticDescriptor NotSupportedTestCollectionOrderer = new DiagnosticDescriptor(
-        "XIT0012",
+        DiagnosticIds.NotSupportedTestCollectionOrderer,
         "DependsOnCollections attribute requires assembly-level TestCollectionOrderer to be DependencyAwareTestCollectionOrderer to respect test dependencies",
         "[DependsOnCollections] attribute requires assembly-level test collection orderer to be DependencyAwareTestCollectionOrderer",
         "Usage",
@@ -106,7 +106,7 @@ internal static class AttributeUsageDescriptors
         description: "Usage of [DependsOnCollections] requires DependencyAwareTestCollectionOrderer set as TestCollectionOrderer, in order for test collections to be ordered according to defined dependencies.");
 
     public static readonly DiagnosticDescriptor DependsOnClassesDependencyAlreadyInCollection = new DiagnosticDescriptor(
-        "XIT0013",
+        DiagnosticIds.DependsOnClassesDependencyAlreadyInCollection,
         "DependsOnClasses dependency type already belongs to a collection",
         "Dependency type '{0}' already belongs to a collection; use [DependsOnCollections] directly to declare collection-level dependencies",
         "Usage",
@@ -115,7 +115,7 @@ internal static class AttributeUsageDescriptors
         description: "[DependsOnClasses] should only reference classes that are not already part of a collection. If the dependency class has [Collection] or [CollectionDefinition], use [DependsOnCollections] on the collection definition instead.");
 
     public static readonly DiagnosticDescriptor DependsOnClassesDependencyNotInCollection = new DiagnosticDescriptor(
-        "XIT0014",
+        DiagnosticIds.DependsOnClassesDependencyNotInCollection,
         "DependsOnClasses dependency type is not part of a named collection",
         "Dependency type '{0}' is not part of a named collection; add [DependsOnClasses(Name = \"...\")] to it so a collection definition is generated",
         "Usage",
@@ -124,7 +124,7 @@ internal static class AttributeUsageDescriptors
         description: "Each dependency in [DependsOnClasses] must belong to a named collection so that collection ordering works reliably. Add [DependsOnClasses(Name = \"...\")] to the dependency class to ensure a collection definition is auto-generated for it.");
 
     public static readonly DiagnosticDescriptor MultipleDependsOnAttributes = new DiagnosticDescriptor(
-        "XIT0015",
+        DiagnosticIds.MultipleDependsOnAttributes,
         "Method has multiple DependsOn attributes",
         "Method '{0}' has multiple attributes derived from DependsOnAttributeBase; only one is allowed per method",
         "Usage",
@@ -133,7 +133,7 @@ internal static class AttributeUsageDescriptors
         description: "A test method should have at most one attribute derived from DependsOnAttributeBase (e.g. [FactDependsOn] or [TheoryDependsOn]). Having multiple dependency attributes on the same method is not supported.");
 
     public static readonly DiagnosticDescriptor DependsOnWithOtherFactAttributes = new DiagnosticDescriptor(
-        "XIT0016",
+        DiagnosticIds.DependsOnWithOtherFactAttributes,
         "Method has DependsOn attribute combined with another IFactAttribute",
         "Method '{0}' has an attribute derived from DependsOnAttributeBase combined with another IFactAttribute; use only the DependsOn attribute",
         "Usage",

--- a/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/DiagnosticIds.cs
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/DiagnosticIds.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Xunit.v3.IntegrationTesting.Analyzers;
 
 internal static class DiagnosticIds
@@ -17,4 +19,6 @@ internal static class DiagnosticIds
     public const string DependsOnClassesDependencyNotInCollection = "XIT0014";
     public const string MultipleDependsOnAttributes = "XIT0015";
     public const string DependsOnWithOtherFactAttributes = "XIT0016";
+    public static string CreateLink(string id) =>
+        string.Format(CultureInfo.InvariantCulture, "https://github.com/olstakh/XUnit-v3-IntegrationTesting/blob/main/docs/Rules/{0}.md", id);
 }

--- a/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/DiagnosticIds.cs
+++ b/src/Xunit.v3.IntegrationTesting.Analyzers/Analyzers/DiagnosticIds.cs
@@ -1,0 +1,20 @@
+namespace Xunit.v3.IntegrationTesting.Analyzers;
+
+internal static class DiagnosticIds
+{
+    public const string NotSupportedClassLevelTestCaseOrderer = "XIT0001";
+    public const string NotSupportedAssemblyLevelTestCaseOrderer = "XIT0002";
+    public const string MissingTestCaseAndCollectionOrderer = "XIT0003";
+    public const string DependsOnMissingMethod = "XIT0004";
+    public const string MissingTestFrameworkAttribute = "XIT0006";
+    public const string NotSupportedTestFrameworkAttribute = "XIT0007";
+    public const string UseFactDependsOnAttribute = "XIT0008";
+    public const string InvalidDependsOnCollectionsAttributeUsage = "XIT0009";
+    public const string CollectionDefinitionMissingDisableParallelization = "XIT0010";
+    public const string MissingTestCollectionOrderer = "XIT0011";
+    public const string NotSupportedTestCollectionOrderer = "XIT0012";
+    public const string DependsOnClassesDependencyAlreadyInCollection = "XIT0013";
+    public const string DependsOnClassesDependencyNotInCollection = "XIT0014";
+    public const string MultipleDependsOnAttributes = "XIT0015";
+    public const string DependsOnWithOtherFactAttributes = "XIT0016";
+}


### PR DESCRIPTION
This pull request adds comprehensive documentation for all analyzer rules in the `Xunit.v3.IntegrationTesting` package, including a summary table, individual rule details, and explanations of the new `[DependsOnClasses]` attribute. It also updates the shipped analyzer release notes to reflect the addition of these new rules.

**Documentation of analyzer rules:**

* Added a summary table of all `Xunit.v3.IntegrationTesting` analyzer rules, including rule IDs, categories, descriptions, severities, enablement, and code fix availability in `docs/README.md`.
* Added detailed documentation for rules XIT0001–XIT0016, each describing the rule's purpose, source, severity, and how to resolve violations, in individual files under `docs/Rules/`. [[1]](diffhunk://#diff-8802a6878236d553297c490c7611904b4a38b5e4af5ff6fbda3821385a64fd0aR1-R29) [[2]](diffhunk://#diff-27dfad57d5f75dc2363fd2b31d5ed8f24b2cf843a563fa438620fd6e8e8a71f9R1-R21) [[3]](diffhunk://#diff-8bf7ce3051ad101f8ca7b6685938b24b20b9beb8cf26100b16e5ddade1544d86R1-R21) [[4]](diffhunk://#diff-c8e939dd6893e3866766e0efac13b706d5650e737ee22e035d0ff87d9638ec23R1-R25) [[5]](diffhunk://#diff-eec3340efbbeb606a35750d666afb306a014d7119aa9852d87d47cfde6f18d85R1-R21) [[6]](diffhunk://#diff-4c9e53bfd33ed77352d7bd44f4dda2e925f1653f07a1d1c57c19fc6126e3afe1R1-R25) [[7]](diffhunk://#diff-5d46a5c6870e57efe29dfdcab00a88981fd901c3a0169c451a79d09ec2a106e8R1-R31) [[8]](diffhunk://#diff-d861ab235af712117d2370764dfc34c16128781231dcb1d51f3df084f95dd986R1-R23) [[9]](diffhunk://#diff-19625cdb39c68e755a3866c96d3cb1ec7f5904becae3435ca48c36526c132e6aR1-R23) [[10]](diffhunk://#diff-4e3012f072c04d11fa08b88176768f29edd8c6e8c1b0885cf2850cc1d16bcd49R1-R21) [[11]](diffhunk://#diff-8c948b3cb8a38e9d32858a75e5c5be24ee9e1084dd39c8571da2695b96eb53d2R1-R21) [[12]](diffhunk://#diff-a9d64102f8d594c9211734225df3e123d60930918a63d554845760ee2acedd76R1-R23) [[13]](diffhunk://#diff-64d45a231fd7962b9c88e1a9870096825adb500cbd0ce98e168620f4d8b5109fR1-R26) [[14]](diffhunk://#diff-b0289a96ed5efc899d0fd50c2bae81ddfa8f812614436aeec7f39709c948b371R1-R28) [[15]](diffhunk://#diff-d666bfbcd0caaca536b7bae8f279f561095782ed11e999411611d1f4078789c0R1-R28)

**Enhancements to usage documentation:**

* Expanded `Test-collection-dependencies.md` with a new section explaining the `[DependsOnClasses]` attribute, its syntax, source generation behavior, and how it interacts with analyzer rules XIT0013 and XIT0014.

**Analyzer release notes:**

* Updated `AnalyzerReleases.Shipped.md` to document the release of version 1.0.11 and list all new analyzer rules with their categories, severities, and summaries.