### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/olstakh/XUnit-v3-IntegrationTesting/security/code-scanning/1](https://github.com/olstakh/XUnit-v3-IntegrationTesting/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is minimally scoped.  
Best fix: define workflow-level permissions right after `on:` (or after `name:`/event block), setting `contents: read`. This preserves current functionality (`checkout` still works) and prevents unintended write access if repository/org defaults are broader.

**File to change:** `.github/workflows/pr.yml`  
**Specific change:** Insert:

```yml
permissions:
  contents: read
```

at the top level before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
